### PR TITLE
fix undef value as an ARRAY reference and warning

### DIFF
--- a/lib/Code/CutNPaste.pm
+++ b/lib/Code/CutNPaste.pm
@@ -190,8 +190,9 @@ sub find_dups {
     my $fork = Parallel::ForkManager->new( $jobs || 1 );
     $fork->run_on_finish(
         sub {
-            my $duplicates = pop @_;
-            push @{ $self->_duplicates } => @$duplicates;
+            if ( my $duplicates = pop @_ ) {
+                push @{ $self->_duplicates } => @$duplicates;
+            }
         }
     );
 
@@ -481,10 +482,11 @@ sub _postfilter {
     my @contents;
     INDEX: for ( my $i = 0; $i < @$contents; $i++ ) {
         if ( $contents->[$i]{code} =~ /^(\s*)BEGIN\s*\{/ ) {    #    BmEGIN {
-            my $padding = $1;
-            if ( $contents->[ $i + 1 ]{code} =~ /^$padding}/ ) {
-                $i++;
-                next INDEX;
+            if ( my $padding = $1 ) {
+                if ( $contents->[ $i + 1 ]{code} =~ /^$padding}/ ) {
+                    $i++;
+                    next INDEX;
+                }
             }
         }
         push @contents => $contents->[$i];


### PR DESCRIPTION
try as i might i couldn't replicate this issue so couldn't write a
test case, i suspect it may be a bug in Parallel::ForkManager,
nonetheless here is a fix to prevent using an undefined value as
an ARRAY ref and also a fix to a warning
